### PR TITLE
rename: MeasurmentRouter, fix: MeasurementAPI, MockMeasurementProtocol, add: MeasurementResult

### DIFF
--- a/VitalWink.xcodeproj/project.pbxproj
+++ b/VitalWink.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		0663C46A2A1B445E00B85ABF /* ExpressionAnalysisMetricValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663C4692A1B445E00B85ABF /* ExpressionAnalysisMetricValue.swift */; };
 		0663C46C2A1B489100B85ABF /* BloodPressureMetricValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663C46B2A1B489100B85ABF /* BloodPressureMetricValue.swift */; };
 		0663C4702A1C743900B85ABF /* MinMaxType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663C46F2A1C743900B85ABF /* MinMaxType.swift */; };
+		0663C4722A1C7D3100B85ABF /* MeasurementResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663C4712A1C7D3100B85ABF /* MeasurementResult.swift */; };
 		06F1809B2A15C64300F1CE90 /* VitalWinkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F1809A2A15C64300F1CE90 /* VitalWinkAPI.swift */; };
 		06F1809F2A15DEFC00F1CE90 /* VitalWinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F1809E2A15DEFC00F1CE90 /* VitalWinkRouter.swift */; };
 		06F180A22A15E95C00F1CE90 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F180A12A15E95C00F1CE90 /* AuthInterceptor.swift */; };
@@ -104,6 +105,7 @@
 		0663C4692A1B445E00B85ABF /* ExpressionAnalysisMetricValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionAnalysisMetricValue.swift; sourceTree = "<group>"; };
 		0663C46B2A1B489100B85ABF /* BloodPressureMetricValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodPressureMetricValue.swift; sourceTree = "<group>"; };
 		0663C46F2A1C743900B85ABF /* MinMaxType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinMaxType.swift; sourceTree = "<group>"; };
+		0663C4712A1C7D3100B85ABF /* MeasurementResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementResult.swift; sourceTree = "<group>"; };
 		06F1809A2A15C64300F1CE90 /* VitalWinkAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalWinkAPI.swift; sourceTree = "<group>"; };
 		06F1809E2A15DEFC00F1CE90 /* VitalWinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalWinkRouter.swift; sourceTree = "<group>"; };
 		06F180A12A15E95C00F1CE90 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				0663C4692A1B445E00B85ABF /* ExpressionAnalysisMetricValue.swift */,
 				0663C46B2A1B489100B85ABF /* BloodPressureMetricValue.swift */,
 				0663C46F2A1C743900B85ABF /* MinMaxType.swift */,
+				0663C4712A1C7D3100B85ABF /* MeasurementResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -610,6 +613,7 @@
 				063C16202A0DE2B600E07141 /* DependencyValues + Extension.swift in Sources */,
 				06F1809B2A15C64300F1CE90 /* VitalWinkAPI.swift in Sources */,
 				06F180A42A15EAF400F1CE90 /* KeyChainManager.swift in Sources */,
+				0663C4722A1C7D3100B85ABF /* MeasurementResult.swift in Sources */,
 				0663C4702A1C743900B85ABF /* MinMaxType.swift in Sources */,
 				063C16252A0DF5E600E07141 /* CameraStreamDelegate.swift in Sources */,
 				063C16142A0B645100E07141 /* UIImage + Extension.swift in Sources */,

--- a/VitalWink/Measurement/Model/MeasurementResult.swift
+++ b/VitalWink/Measurement/Model/MeasurementResult.swift
@@ -1,0 +1,37 @@
+//
+//  MeasurementResult.swift
+//  VitalWink
+//
+//  Created by 유호준 on 2023/05/23.
+//
+
+import Foundation
+struct MeasurementResult: Codable{
+    let bpm: Int
+    let SpO2: Int
+    let RR: Int
+    let stress: Int
+
+    let BMI: Int?
+    let expressionAnalysis: ExpressionAnalysis?
+
+    let bloodPressure: BloodPressure?
+    let bloodSugar: Int?
+    
+    init(bpm: Int, SpO2: Int, RR: Int, stress: Int, BMI: Int? = nil, expressionAnalysis: ExpressionAnalysis? = nil, bloodPressure: BloodPressure?  = nil, bloodSugar: Int? = nil) {
+        self.bpm = bpm
+        self.SpO2 = SpO2
+        self.RR = RR
+        self.stress = stress
+        self.BMI = BMI
+        self.expressionAnalysis = expressionAnalysis
+        self.bloodPressure = bloodPressure
+        self.bloodSugar = bloodSugar
+    }
+    
+    
+    #if DEBUG
+    static let faceMeasurementMock =  MeasurementResult(bpm: 100, SpO2: 100, RR: 10, stress: 100, BMI: 100, expressionAnalysis: .init(valence: 1.0, arousal: 1.0))
+    static let fingeMeasurementMock =  MeasurementResult(bpm: 100, SpO2: 100, RR: 10, stress: 100, bloodPressure: .init(SYS: 100, DIA: 100), bloodSugar: 100)
+    #endif
+}

--- a/VitalWink/Measurement/Model/RecentData.swift
+++ b/VitalWink/Measurement/Model/RecentData.swift
@@ -11,7 +11,7 @@ struct RecentData: Codable{
     let bpm: Int?
     let SpO2: Int?
     let RR: Int?
-    let stressIndex: Int?
+    let stress: Int?
     
     let BMI: Int?
     let expressionAnalysis: ExpressionAnalysis?
@@ -19,6 +19,6 @@ struct RecentData: Codable{
     let bloodSugar: Int?
     
     #if DEBUG
-    static let mock = RecentData(bpm: 100, SpO2: 100, RR: 10, stressIndex: 10, BMI: 10, expressionAnalysis: .init(valence: 1.0, arousal: 1.0), bloodPressure: .init(SYS: 100, DIA: 70), bloodSugar: 100)
+    static let mock = RecentData(bpm: 100, SpO2: 100, RR: 10, stress: 10, BMI: 10, expressionAnalysis: .init(valence: 1.0, arousal: 1.0), bloodPressure: .init(SYS: 100, DIA: 70), bloodSugar: 100)
     #endif
 }

--- a/VitalWink/Measurement/Network/MeasurementAPI.swift
+++ b/VitalWink/Measurement/Network/MeasurementAPI.swift
@@ -12,13 +12,13 @@ import Combine
 import SwiftyJSON
 
 final class MeasurmentAPI{
-    func signalMeasurment(frames: [[[UInt8]]], type: MeasurmentRouter.Target) -> AnyPublisher<Int, Error>{
+    func signalMeasurment(frames: [[[UInt8]]], type: MeasurementRouter.Target) -> AnyPublisher<Int, Error>{
         return Future<Int, Error>{[weak self] promise in
             guard let strongSelf = self else{
                 return
             }
             
-            strongSelf.vitalWinkAPI.request(MeasurmentRouter.signalMeasurement(frames: frames, target: type))
+            strongSelf.vitalWinkAPI.request(MeasurementRouter.signalMeasurement(frames: frames, target: type))
                 .validate(statusCode: 201...201)
                 .responseDecodable(of: JSON.self){
                     switch $0.result{
@@ -39,7 +39,7 @@ final class MeasurmentAPI{
     }
     
     func expressionAndBMI(image: UIImage, id: Int) -> AnyPublisher<Never,some Error>{
-        return vitalWinkAPI.upload(MeasurmentRouter.expressionAndBMIMeasurement(image: image, id: id))
+        return vitalWinkAPI.upload(MeasurementRouter.expressionAndBMIMeasurement(image: image, id: id))
             .validate(statusCode: 201 ... 201)
             .publishUnserialized()
             .value()
@@ -48,18 +48,18 @@ final class MeasurmentAPI{
     }
     
     func fetchRecentData() -> AnyPublisher<RecentData, some Error>{
-        return vitalWinkAPI.request(MeasurmentRouter.fetchRecentData)
+        return vitalWinkAPI.request(MeasurementRouter.fetchRecentData)
             .validate(statusCode: 200...200)
             .publishDecodable(type: RecentData.self)
             .value()
             .eraseToAnyPublisher()
     }
     
-    func fetchMetricDatas<ValueType>(_ metric: MeasurmentRouter.Metric, period: MeasurmentRouter.Period, basisDate: Date, valueType: ValueType.Type = ValueType.self) -> AnyPublisher<[MetricData<ValueType>], some Error> where ValueType: Codable{
+    func fetchMetricDatas<ValueType>(_ metric: MeasurementRouter.Metric, period: MeasurementRouter.Period, basisDate: Date, valueType: ValueType.Type = ValueType.self) -> AnyPublisher<[MetricData<ValueType>], some Error> where ValueType: Codable{
    
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return vitalWinkAPI.request(MeasurmentRouter.fetchMetricDatas(metric, period: period, basisDate: basisDate))
+        return vitalWinkAPI.request(MeasurementRouter.fetchMetricDatas(metric, period: period, basisDate: basisDate))
             .validate(statusCode: 200...200)
             .publishDecodable(type: MetricDataResponse<ValueType>.self, decoder: decoder)
             .value()
@@ -68,6 +68,13 @@ final class MeasurmentAPI{
         
     }
     
+    func fetchMeasurementResult(_ id: Int) -> AnyPublisher<MeasurementResult, some Error>{
+        return vitalWinkAPI.request(MeasurementRouter.fetchMeasurementResult(id))
+            .validate(statusCode: 200...200)
+            .publishDecodable(type: MeasurementResult.self)
+            .value()
+            .eraseToAnyPublisher()
+    }
     @Dependency(\.vitalWinkAPI) private var vitalWinkAPI
 }
 

--- a/VitalWink/Measurement/Network/MeasurementRouter.swift
+++ b/VitalWink/Measurement/Network/MeasurementRouter.swift
@@ -8,11 +8,12 @@
 import Foundation
 import Alamofire
 
-enum MeasurmentRouter: VitalWinkUploadableRouterType{
+enum MeasurementRouter: VitalWinkUploadableRouterType{
     case signalMeasurement(frames: [[[UInt8]]], target: Target)
     case expressionAndBMIMeasurement(image: UIImage, id: Int)
     case fetchRecentData
     case fetchMetricDatas(_ metric: Metric, period: Period, basisDate: Date)
+    case fetchMeasurementResult(_ id: Int)
     
     var endPoint: String{
         let baseEndPoint = "measurements"
@@ -28,6 +29,8 @@ enum MeasurmentRouter: VitalWinkUploadableRouterType{
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd"
             detailEndPoint = "\(metric.rawValue)/\(period.rawValue)/\(dateFormatter.string(from: basisDate))"
+        case .fetchMeasurementResult(let id):
+            detailEndPoint = "\(id)"
         }
         
         return  "\(baseEndPoint)/\(detailEndPoint)"
@@ -37,7 +40,7 @@ enum MeasurmentRouter: VitalWinkUploadableRouterType{
         switch self {
         case .signalMeasurement, .expressionAndBMIMeasurement:
             return .post
-        case .fetchRecentData, .fetchMetricDatas:
+        case .fetchRecentData, .fetchMetricDatas, .fetchMeasurementResult:
             return .get
         }
     }
@@ -65,7 +68,7 @@ enum MeasurmentRouter: VitalWinkUploadableRouterType{
         case .expressionAndBMIMeasurement(image: let image, id: let id):
             formData.append(image.jpegData(compressionQuality: 0.5)!, withName: "image", mimeType: "image/jpeg")
             var id = id
-            formData.append(Data(bytes: &id, count: MemoryLayout<Int>.size), withName: "measurment_id")
+            formData.append(Data(bytes: &id, count: MemoryLayout<Int>.size), withName: "measurement_id")
         default:
             return
         }

--- a/VitalWink/Measurement/Network/MockMeasurementProtocol.swift
+++ b/VitalWink/Measurement/Network/MockMeasurementProtocol.swift
@@ -56,6 +56,7 @@ extension MockMeasurmentProtocol{
         case expressionAndBMI
         case fetchRecentData
         case fetchMetricDatas
+        case fetchMeasurementResult
     }
     static func responseWithFailure(){
         MockMeasurmentProtocol.responseType = MockMeasurmentProtocol.ResponseType.error(MockError.none)
@@ -127,6 +128,10 @@ extension MockMeasurmentProtocol{
                 encoder.dateEncodingStrategy = .iso8601
                 return try! encoder.encode(response)
             }
+            
+            
+        case .fetchMeasurementResult:
+            return try! JSONEncoder().encode(MeasurementResult.faceMeasurementMock)
         default:
             return Data()
         }

--- a/VitalWinkTests/MeasurementAPITest.swift
+++ b/VitalWinkTests/MeasurementAPITest.swift
@@ -91,6 +91,25 @@ final class MeasurementAPITest: XCTestCase {
         }).store(in: &subsriptions)
         wait(for: [expectation], timeout: 5)
     }
+    
+    func test_fetchMeasurementResult(){
+        MockMeasurmentProtocol.responseWithStatusCode(code: 200)
+        MockMeasurmentProtocol.responseWithData(type: .fetchMeasurementResult)
+        
+        measurementAPI.fetchMeasurementResult(1)
+            .sink(receiveCompletion: {
+                switch $0{
+                case .finished:
+                    self.expectation.fulfill()
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
+                }
+            }, receiveValue: {
+                print($0)
+            }).store(in: &subsriptions)
+        
+        wait(for: [expectation], timeout: 5)
+    }
 }
 
 


### PR DESCRIPTION
- 오타 수정
- 측정 결과 조회를 위한 함수 및 테스트 추가
- 측정 결과를 표현하기 위한 객체 추가